### PR TITLE
Enable delete branch on merge for newRepo 'store'

### DIFF
--- a/otterdog/eclipse-store.jsonnet
+++ b/otterdog/eclipse-store.jsonnet
@@ -54,7 +54,7 @@ orgs.newOrg('technology.store', 'eclipse-store') {
     orgs.newRepo('store') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       description: "High-Performance Java-Native-Persistence. Store and load any Java Object Graph or Subgraphs partially, Relieved of Heavy-weight JPA. Microsecond Response Time. Ultra-High Throughput. Minimum of Latencies. Create Ultra-Fast In-Memory Database Applications & Microservices.",
       has_discussions: true,
       homepage: "https://eclipsestore.io/",


### PR DESCRIPTION
This pull request makes a small but important configuration change to the `store` repository under the `eclipse-store` organization. The change ensures that branches are automatically deleted after a pull request is merged, helping to keep the repository clean and organized.

- Repository settings update:
  * Enabled automatic branch deletion after merge by setting `delete_branch_on_merge` to `true` in the `store` repository configuration.